### PR TITLE
refine README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ chai-roughly
 ![CI Build](https://github.com/micdah/chai-roughly/actions/workflows/ci.yml/badge.svg)
 [![npm](https://img.shields.io/npm/v/chai-roughly-v2.svg)](https://www.npmjs.com/package/chai-roughly-v2)
 
-deep equals assertions with tolerance for chai.
+Deep equal assertions with tolerance for [chai](https://www.npmjs.com/package/chai).
 
 ### Why a v2?
 
@@ -20,7 +20,7 @@ npm install --save-dev chai-roughly-v2
 
 ## Usage
 
-After importing `chai` add the following code to use `chai-roughly-v2` assertions:
+After importing `chai`, add the following code to use `chai-roughly-v2` assertions:
 
 ```js
 const chai = require('chai');
@@ -34,8 +34,9 @@ and can be overwritten by using e.g.
 `expect(...).to.roughly(0.001).deep.equal(...)`.
 
 ```js
-it('works', function () {
-    expect({value: 42}).to.roughly.deep.equal({value: 41.9999999});
+it('works', () => {
+  const x = 41.9999999;
+  expect(x).to.roughly.deep.equal({ value: 42 });
 });
 ```
 


### PR DESCRIPTION
- you can google `"deep equals assertion"` (which finds only two results) vs `"deep equal assertion"` (which finds plenty of results
- I used an arrow function as it looks simpler than a normal function, and `this` isn't used anywhere
- I guess that a round value should be used on the right side (instead of the left side) which seems to be more close to a real case usage (we compare a result which might be a number with many digits after the comma with an expected value which is an integer)
- I added space near the curlies which seems for me to be a much more common JS coding style